### PR TITLE
fix(envs): remove defaults channel to fix conda solver hang

### DIFF
--- a/envs/env-hpc.yml
+++ b/envs/env-hpc.yml
@@ -3,7 +3,8 @@ channels:
   - pytorch
   - nvidia
   - conda-forge
-  - defaults
+  # NOTE: Do NOT add 'defaults' here. Miniforge uses conda-forge only.
+  # Adding defaults causes solver hangs due to cross-channel conflicts.
 
 # =============================================================================
 # KINTSUGI HPC Environment (HiPerGator / SLURM Clusters)
@@ -69,11 +70,12 @@ dependencies:
   # PyTorch installed from pytorch channel (not pip) to avoid conflicts.
   # cuda-libraries provides libcufft, libcublas, libcusolver needed by CuPy.
   # cuda-cudart-dev provides headers for CuPy JIT compilation.
+  # Versions pinned to reduce solver space and avoid cross-channel conflicts.
   - pytorch>=2.0
   - torchvision
   - pytorch-cuda=12.4
-  - cuda-libraries
-  - cuda-cudart-dev
+  - cuda-libraries=12.*
+  - cuda-cudart-dev=12.*
 
   # === Spatial Analysis (conda-forge) ===
   # These packages have C extensions (leidenalg, hdbscan) that are

--- a/envs/env-linux.yml
+++ b/envs/env-linux.yml
@@ -1,7 +1,8 @@
 name: KINTSUGI
 channels:
   - conda-forge
-  - defaults
+  # NOTE: Do NOT add 'defaults' here. Miniforge uses conda-forge only.
+  # Adding defaults causes solver hangs due to cross-channel conflicts.
 
 # =============================================================================
 # KINTSUGI Base Environment for Linux

--- a/envs/env-macos.yml
+++ b/envs/env-macos.yml
@@ -1,7 +1,6 @@
 name: KINTSUGI
 channels:
   - conda-forge
-  - defaults
 
 # =============================================================================
 # KINTSUGI Base Environment for macOS

--- a/envs/env-windows.yml
+++ b/envs/env-windows.yml
@@ -1,7 +1,6 @@
 name: KINTSUGI
 channels:
   - conda-forge
-  - defaults
 
 # =============================================================================
 # KINTSUGI Base Environment for Windows


### PR DESCRIPTION
## Summary

- Remove `defaults` channel from all 4 conda env files to fix solver hang on miniforge
- Pin CUDA packages to `12.*` in env-hpc.yml to reduce solver search space

## Problem

`conda env create -f envs/env-hpc.yml` hangs indefinitely at "solving environment" on HiPerGator (miniforge). The same issue affects env-linux.yml.

## Root Cause

Miniforge uses conda-forge exclusively. Adding the `defaults` (Anaconda) channel forces the solver to:
1. Download the entire defaults channel metadata
2. Reconcile overlapping packages with different build strings across channels
3. For env-hpc.yml, explore combinations across 4 channels (pytorch + nvidia + conda-forge + defaults)

This creates a combinatorial explosion that the solver cannot resolve in reasonable time.

## Fix

- Remove `defaults` from all env files (linux, hpc, macos, windows)
- Pin `cuda-libraries=12.*` and `cuda-cudart-dev=12.*` in env-hpc.yml to constrain the nvidia channel search space
- Add comments warning against re-adding defaults

## Test plan

- [ ] Verify `conda env create -f envs/env-hpc.yml` completes on HiPerGator
- [ ] Verify `conda env create -f envs/env-linux.yml` completes
- [ ] CI passes (lint + tests on Python 3.10/3.11/3.12)

https://claude.ai/code/session_01SSVQYCkyoMZsen3eYKGCe5