### PR TITLE
feat(mcp): migrate server to FastMCP with structured tool output

### DIFF
--- a/.github/workflows/mcp-eval.yml
+++ b/.github/workflows/mcp-eval.yml
@@ -1,0 +1,102 @@
+name: MCP Eval
+
+# Evaluates the KINTSUGI MCP tool surface.
+#   * Structural pass (token cost, schema quality, tool coverage): runs on every
+#     PR as a fast, deterministic gate (no API key, --strict fails on regressions
+#     such as a documented-but-unregistered tool).
+#   * Agentic tool-selection pass: runs on manual dispatch and weekly schedule
+#     only, and only when an ANTHROPIC_API_KEY secret is configured (it spends
+#     API tokens and is nondeterministic, so it never runs on PRs).
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "src/kintsugi/mcp/**"
+      - "evals/mcp/**"
+      - ".github/workflows/mcp-eval.yml"
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model for the agentic tool-selection eval"
+        default: "claude-sonnet-4-6"
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mcp-eval:
+    name: MCP tool-surface eval
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvips-dev
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" anthropic
+
+      - name: Run MCP evaluation
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_MODEL: ${{ github.event.inputs.model || 'claude-sonnet-4-6' }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+            python evals/mcp/harness.py --agentic --model "$EVAL_MODEL" --strict --json mcp_eval_report.json
+          else
+            if [ "${{ github.event_name }}" != "pull_request" ]; then
+              echo "::notice::ANTHROPIC_API_KEY secret not set — running the structural eval only."
+            fi
+            python evals/mcp/harness.py --strict --json mcp_eval_report.json
+          fi
+
+      - name: Write job summary
+        if: always()
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+          p = pathlib.Path("mcp_eval_report.json")
+          if not p.exists():
+              print("No eval report produced.")
+              raise SystemExit(0)
+          r = json.loads(p.read_text())
+          s = r["structural"]
+          print("## MCP tool-surface eval\n")
+          print(f"- Tools: **{s['tool_count']}** (output schemas: "
+                f"{s['tools_with_output_schema']}/{s['tool_count']})")
+          print(f"- Tool-definition tokens (est.): **~{s['total_definition_tokens_est']:,}**")
+          print(f"- Params missing description: {s['params_missing_description_count']}")
+          gaps = s["task_coverage_gaps"]
+          print(f"- Task coverage gaps: {gaps if gaps else 'none'}")
+          a = r.get("agentic")
+          if a:
+              print(f"\n### Agentic tool-selection: **{a['passed']}/{a['total']} = "
+                    f"{a['accuracy']:.0%}** (model `{a['model']}`)\n")
+              fails = [x for x in a["results"] if not x["pass"]]
+              if fails:
+                  print("| task | chose | expected |")
+                  print("|------|-------|----------|")
+                  for x in fails:
+                      print(f"| {x['task']} | {x['chosen']} | {', '.join(x['expected'])} |")
+          else:
+              print("\n_Agentic pass skipped (PR event or no ANTHROPIC_API_KEY secret)._")
+          PY
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-eval-report
+          path: mcp_eval_report.json

--- a/docs/skills/mcp-fastmcp-structured-output/.claude-plugin/plugin.json
+++ b/docs/skills/mcp-fastmcp-structured-output/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-fastmcp-structured-output",
+  "version": "1.0.0",
+  "description": "Migrate a Python MCP server to FastMCP with structured tool output, preserve curated schemas, and evaluate the tool surface. Trigger when: (1) migrating kintsugi.mcp or any low-level mcp.server.Server to FastMCP, (2) adding structured output / outputSchema to MCP tools, (3) an MCP tool result fails output validation with 'None is not of type ...', (4) preserving per-parameter descriptions or enums under FastMCP's auto schemas, (5) building an MCP tool-selection evaluation harness or wiring it into CI.",
+  "author": {
+    "name": "KINTSUGI Team"
+  },
+  "skills": "./skills",
+  "repository": "https://github.com/smith6jt-cop/Skills_Registry"
+}

--- a/docs/skills/mcp-fastmcp-structured-output/PUBLISHING.md
+++ b/docs/skills/mcp-fastmcp-structured-output/PUBLISHING.md
@@ -1,0 +1,30 @@
+# Publishing this skill to the Skills Registry
+
+This is a drafted `/retrospective` skill, preserved in the KINTSUGI repo because
+the `Skills_Registry` is a **separate** repository
+(`github.com/smith6jt-cop/Skills_Registry`). It already passed the registry's
+validator locally (`OK mcp-fastmcp-structured-output`).
+
+To publish it:
+
+```bash
+# from the KINTSUGI repo root
+git submodule update --init Skills_Registry
+cp -r docs/skills/mcp-fastmcp-structured-output Skills_Registry/plugins/kintsugi/
+
+cd Skills_Registry
+git checkout main && git pull            # leave the detached submodule HEAD
+python scripts/generate_marketplace.py   # adds it to marketplace.json
+python scripts/validate_plugins.py       # expect: OK mcp-fastmcp-structured-output
+git add plugins/kintsugi/mcp-fastmcp-structured-output marketplace.json
+git commit -m "feat(kintsugi): add mcp-fastmcp-structured-output skill"
+git push
+```
+
+Optionally, bump the submodule pointer in KINTSUGI afterward:
+
+```bash
+cd ..                # back to KINTSUGI root
+git add Skills_Registry
+git commit -m "chore: bump Skills_Registry (add mcp-fastmcp-structured-output)"
+```

--- a/docs/skills/mcp-fastmcp-structured-output/skills/mcp-fastmcp-structured-output/SKILL.md
+++ b/docs/skills/mcp-fastmcp-structured-output/skills/mcp-fastmcp-structured-output/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: mcp-fastmcp-structured-output
+description: "Migrate a low-level MCP server to FastMCP with structured output, preserve curated input schemas, and evaluate the tool surface. Trigger: FastMCP migration, adding outputSchema/structuredContent, 'None is not of type' output-validation errors, building MCP tool-selection evals."
+author: KINTSUGI Team
+date: 2026-06-22
+---
+
+# MCP Server: FastMCP Migration + Structured Output + Evaluation
+
+## Experiment Overview
+| Item | Details |
+|------|---------|
+| **Date** | 2026-06-22 |
+| **Goal** | Migrate `kintsugi.mcp` from low-level `mcp.server.Server` to FastMCP, deliver structured tool output, and stand up an evaluation/improvement workflow |
+| **Environment** | `mcp==1.27.2` (floor `>=1.10`), Python 3.11/3.12, FastMCP (`mcp.server.fastmcp`) |
+| **Status** | Success |
+
+## Context
+The MCP server hand-wrote a `Tool(...)` list + an `elif` dispatch in `call_tool`,
+returned only `TextContent` (a JSON string), and exposed no output schemas. Goal:
+move to FastMCP so each tool returns machine-readable `structuredContent`, on a
+foundation that makes later resources/prompts/elicitation cheap.
+
+## What Worked (verified approach)
+
+1. **Floor `mcp>=1.10.0,<2`.** Structured output (`Tool.outputSchema`,
+   `CallToolResult.structuredContent`, FastMCP `structured_output`) and
+   elicitation **do not exist below 1.10** (the SDK release after spec 2025-06-18).
+
+2. **Register existing handlers; keep them FastMCP-agnostic.** A declarative
+   registry (`tool_specs.py`: name → module/attr + description + input schema)
+   plus, in `server.py`:
+   ```python
+   server = FastMCP("kintsugi")
+   handler = getattr(module, spec["attr"])           # plain async dict-returning fn
+   server.add_tool(handler, name=spec["name"],
+                   description=spec["description"], structured_output=True)
+   ```
+   Handlers stay plain `async` functions returning `dict[str, Any]`, so the unit
+   tests keep calling them directly.
+
+3. **Returns: `dict[str, Any]` + `structured_output=True`.** FastMCP then emits
+   the dict as `structuredContent` **and** a JSON text block, for both the
+   success and the in-band `{"error": ...}` branches — no per-tool models needed.
+
+4. **Preserve curated input schemas (descriptions + enums) by overriding** the
+   advertised schema after registration; validation still runs from the handler
+   signature:
+   ```python
+   # FastMCP's signature-derived schema drops per-param descriptions + enums.
+   server._tool_manager.get_tool(name).parameters = curated_input_schema  # wrap in try/except
+   ```
+
+5. **Evaluation harness** (`evals/mcp/`): a structural pass (tool-definition token
+   cost, schema-quality checks, confusable-group flags, task coverage) + an
+   agentic pass (`tool_choice="auto"`, score the model's first `tool_use`).
+   Tool **selection** needs only the schemas — **no image data or handler
+   execution** — so it runs with just an API key. Wire agentic into CI behind an
+   `ANTHROPIC_API_KEY` secret (manual + scheduled); gate PRs with the structural
+   `--strict` pass. The harness immediately found `analyze_weighted_subtraction`
+   documented + implemented but **never registered**.
+
+## What Failed (do not repeat)
+
+| Attempt | Result |
+|---------|--------|
+| Strict `TypedDict` returns (`total=False`) to get rich per-field outputSchema | **FAILED.** FastMCP materializes absent keys as `None`, then validates against the non-nullable field type → `Output validation error: None is not of type 'string'`, `structuredContent=None`, `isError=True` on **both** success and error returns |
+| `Optional`-field `TypedDict`s (to dodge the above) | Validates, but **pollutes every result** with `null` keys for absent fields (noisy/misleading) → use plain `dict[str, Any]` instead |
+| Rely on docstrings for per-parameter descriptions under FastMCP | **FAILED.** FastMCP 1.27 does **not** parse docstring args; descriptions are dropped. Use `Annotated[T, Field(description=...)]` or override `.parameters` |
+| Raise the `mcp` floor only in `pyproject.toml` extras | **Incomplete.** `src/kintsugi/deps.py` `OPTIONAL_GROUPS` is a parallel source of truth used by `kintsugi install`/`check` — update both (`claude` *and* `dev`) |
+
+## Verification
+- `pytest tests/test_mcp_tools.py tests/test_mcp_path_safety.py` — direct-call
+  tests stay green (handlers unchanged); add an in-memory client test
+  (`mcp.shared.memory.create_connected_server_and_client_session`) asserting
+  `outputSchema` present + `structuredContent` populated + text block + error
+  branch clean.
+- `python evals/mcp/harness.py --strict` — structural gate (fails on coverage
+  gaps / missing descriptions).
+- Preserve the `create_server()` `ImportError` contract by simulating
+  `MCP_AVAILABLE = False` (don't swallow the import in a bare `except`).
+
+## Key Files (reference implementation)
+- `src/kintsugi/mcp/server.py` — FastMCP wiring, `_advertise_schema` override
+- `src/kintsugi/mcp/tool_specs.py` — declarative registry (mcp-free, also feeds `kintsugi mcp tools`)
+- `evals/mcp/{tasks.py,harness.py,README.md}` — evaluation harness
+- `.github/workflows/mcp-eval.yml` — keyed agentic eval + structural PR gate

--- a/evals/mcp/README.md
+++ b/evals/mcp/README.md
@@ -1,0 +1,68 @@
+# KINTSUGI MCP — Evaluation Harness
+
+Measures the quality of the KINTSUGI MCP **tool surface** with realistic tasks
+instead of intuition, following the `mcp-builder` philosophy. Use it to drive and
+verify MCP improvements (tool consolidation, description quality, resources/prompts).
+
+## Why
+
+The server exposes 27 tools to Claude. Two questions decide whether that surface
+is *good*:
+
+1. **Is it cheap and clear?** (structural) — how many tokens do the tool
+   definitions cost, and are any tools/params under-described or confusable?
+2. **Does the model use it correctly?** (agentic) — given a realistic request,
+   does Claude pick the right tool?
+
+## Run it
+
+```bash
+# Structural only — no network, no API key. Runs anywhere mcp is installed.
+python evals/mcp/harness.py
+
+# Agentic tool-selection eval — needs an API key + the anthropic SDK.
+pip install anthropic
+ANTHROPIC_API_KEY=sk-... python evals/mcp/harness.py --agentic --model claude-sonnet-4-6
+
+# Save the full report (structural + agentic) as JSON.
+python evals/mcp/harness.py --agentic --json mcp_eval_report.json
+```
+
+The agentic mode measures **tool selection only** — it records the model's first
+`tool_use` per task and never executes the handler — so it needs **no image data
+or project**, just the live tool schemas.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `tasks.py` | 15 realistic natural-language tasks with `expected` acceptable tool(s). Includes deliberate confusable pairs (`denoise` vs `denoise_advanced`; the three background-removal tools; `assess_quality` vs `compute_snr`). |
+| `harness.py` | Builds the live FastMCP server, runs the structural metrics, and (opt-in) the agentic tool-selection loop. |
+
+Add a task by appending an `EvalTask` to `TASKS`; the structural pass will verify
+its `expected` tools exist on the server.
+
+## Findings (baseline, structural pass)
+
+Run against the post-migration server:
+
+- **27 tools**, **27/27 carry an output schema** (structured output is live).
+- **~3.9k tokens** of tool definitions injected on every call (~144/tool) — modest;
+  no urgent token pressure (compare: GitHub's MCP server ≈ 55k for 43 tools).
+- **0 params missing a description**, **0 tools with weak descriptions** — the
+  curated input schemas held up.
+- **First eval-driven fix:** the harness caught `analyze_weighted_subtraction` —
+  documented in `CLAUDE.md` and implemented, but **never registered**. Now wired up.
+
+### Open items the eval points at (future PRs)
+
+- **Confusable groups** worth either consolidating or giving sharper
+  "Use this when …" descriptions, to be confirmed by the agentic pass:
+  - background removal: `subtract_blank` / `gaussian_subtract` / `estimate_background`
+  - denoising: `denoise` / `denoise_advanced`
+  - parameter suggestion: `suggest_parameters` / `suggest_with_learning` / `get_learned_parameters`
+- **Resources/prompts** (deferred P1 items) — once added, extend the harness with
+  resource-read and prompt tasks.
+
+Run the agentic pass with a key to turn the "confusable groups" hypotheses into
+measured tool-selection accuracy, then act on the tools that get mis-selected.

--- a/evals/mcp/harness.py
+++ b/evals/mcp/harness.py
@@ -213,16 +213,30 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Model (default: {DEFAULT_MODEL}).")
     parser.add_argument("--json", metavar="PATH", help="Write the full report as JSON.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on structural problems (coverage gaps, missing descriptions).",
+    )
     args = parser.parse_args(argv)
 
     tools = load_tools()
-    report: dict[str, Any] = {"structural": run_structural(tools, TASKS)}
+    structural = run_structural(tools, TASKS)
+    report: dict[str, Any] = {"structural": structural}
     if args.agentic:
         report["agentic"] = run_agentic(tools, TASKS, args.model)
 
     if args.json:
         Path(args.json).write_text(json.dumps(report, indent=2))
         print(f"\nWrote report to {args.json}")
+
+    if args.strict and (
+        structural["task_coverage_gaps"]
+        or structural["tools_missing_description"]
+        or structural["params_missing_description_count"]
+    ):
+        print("\nstrict: structural problems detected — failing.", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/evals/mcp/harness.py
+++ b/evals/mcp/harness.py
@@ -1,0 +1,230 @@
+"""Evaluation harness for the KINTSUGI MCP tool surface.
+
+This follows the ``mcp-builder`` philosophy: measure tool quality with realistic
+tasks instead of guessing. It has two modes.
+
+**Structural** (default, no network / API key):
+  * Token cost of the tool definitions injected into every agent context.
+  * Schema-quality checks (missing descriptions, terse/overlong descriptions).
+  * Flags curated confusable tool groups (consolidation candidates).
+  * Confirms every eval task's expected tool exists on the live server.
+
+**Agentic** (``--agentic``, requires ``ANTHROPIC_API_KEY`` + ``anthropic`` SDK):
+  * Presents the live tool schemas to Claude for each task with
+    ``tool_choice=auto`` and records the model's *first* tool call.
+  * Scores tool **selection** (did it pick an acceptable tool?). Because we only
+    measure selection, no image data or handler execution is required.
+
+Run::
+
+    python evals/mcp/harness.py                 # structural only
+    ANTHROPIC_API_KEY=... python evals/mcp/harness.py --agentic
+    python evals/mcp/harness.py --json report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tasks import TASKS  # noqa: E402  (local sibling module)
+
+# Curated groups whose members are easy to confuse and are candidates for
+# consolidation or sharper "Use this when ..." descriptions. Flagged, not failed.
+CONFUSABLE_GROUPS: list[tuple[str, list[str]]] = [
+    ("denoising", ["denoise", "denoise_advanced"]),
+    ("background removal", ["subtract_blank", "gaussian_subtract", "estimate_background"]),
+    ("quality", ["assess_quality", "compute_snr"]),
+    (
+        "parameter suggestion",
+        ["suggest_parameters", "suggest_with_learning", "get_learned_parameters"],
+    ),
+    ("record learning", ["record_successful_parameters", "approve_and_learn"]),
+]
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars/token). Approximate; for relative sizing."""
+    return max(1, round(len(text) / 4))
+
+
+def load_tools() -> list[dict[str, Any]]:
+    """Build the live FastMCP server and return its advertised tool definitions."""
+    try:
+        from kintsugi.mcp.server import MCP_AVAILABLE, create_server
+    except Exception as exc:  # pragma: no cover
+        raise SystemExit(f"Could not import the MCP server: {exc}")
+    if not MCP_AVAILABLE:
+        raise SystemExit("mcp is not installed. Install with: pip install 'mcp>=1.10.0,<2'")
+
+    server = create_server()
+    tools = asyncio.run(server.list_tools())
+    return [
+        {
+            "name": t.name,
+            "description": t.description or "",
+            "input_schema": t.inputSchema or {},
+            "output_schema": t.outputSchema,
+        }
+        for t in tools
+    ]
+
+
+def run_structural(tools: list[dict[str, Any]], tasks: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute and print structural metrics for the tool surface."""
+    names = {t["name"] for t in tools}
+
+    per_tool_tokens: dict[str, int] = {}
+    for t in tools:
+        blob = t["name"] + "\n" + t["description"] + "\n" + json.dumps(t["input_schema"])
+        per_tool_tokens[t["name"]] = estimate_tokens(blob)
+    total_tokens = sum(per_tool_tokens.values())
+
+    # Schema quality.
+    missing_tool_desc = [t["name"] for t in tools if len(t["description"].strip()) < 20]
+    params_missing_desc: list[str] = []
+    have_output_schema = 0
+    for t in tools:
+        if t["output_schema"] is not None:
+            have_output_schema += 1
+        props = (t["input_schema"] or {}).get("properties", {})
+        for pname, pschema in props.items():
+            if not (pschema.get("description") or "").strip():
+                params_missing_desc.append(f"{t['name']}.{pname}")
+
+    # Task coverage.
+    coverage_gaps = [
+        {"task": task["id"], "missing": sorted(set(task["expected"]) - names)}
+        for task in tasks
+        if not set(task["expected"]) & names
+    ]
+
+    report = {
+        "tool_count": len(tools),
+        "total_definition_tokens_est": total_tokens,
+        "mean_tokens_per_tool_est": round(total_tokens / max(1, len(tools)), 1),
+        "tools_with_output_schema": have_output_schema,
+        "top_tools_by_tokens": sorted(per_tool_tokens.items(), key=lambda kv: kv[1], reverse=True)[
+            :5
+        ],
+        "tools_missing_description": missing_tool_desc,
+        "params_missing_description_count": len(params_missing_desc),
+        "confusable_groups": [
+            {"theme": theme, "tools": [m for m in members if m in names]}
+            for theme, members in CONFUSABLE_GROUPS
+        ],
+        "task_coverage_gaps": coverage_gaps,
+    }
+
+    print("=" * 70)
+    print("STRUCTURAL EVALUATION — KINTSUGI MCP tool surface")
+    print("=" * 70)
+    print(f"Tools registered:                 {report['tool_count']}")
+    print(
+        f"Tools with output schema:         {report['tools_with_output_schema']}/{report['tool_count']}"
+    )
+    print(
+        f"Tool-definition tokens (est.):    ~{total_tokens:,} "
+        f"(~{report['mean_tokens_per_tool_est']}/tool, injected every call)"
+    )
+    print(f"Params missing a description:     {report['params_missing_description_count']}")
+    print(f"Tools with weak/no description:   {missing_tool_desc or 'none'}")
+    print("\nHeaviest tools (token est.):")
+    for name, tok in report["top_tools_by_tokens"]:
+        print(f"   {tok:>5}  {name}")
+    print("\nConfusable groups (consolidation / 'Use this when ...' candidates):")
+    for grp in report["confusable_groups"]:
+        print(f"   [{grp['theme']}]  {', '.join(grp['tools'])}")
+    if coverage_gaps:
+        print("\nWARNING — eval tasks referencing absent tools:")
+        for gap in coverage_gaps:
+            print(f"   {gap['task']}: missing {gap['missing']}")
+    else:
+        print(f"\nTask coverage: all {len(tasks)} tasks reference existing tools. OK")
+    return report
+
+
+def run_agentic(
+    tools: list[dict[str, Any]], tasks: list[dict[str, Any]], model: str
+) -> dict[str, Any]:
+    """Score tool *selection*: does the model pick an acceptable tool per task?"""
+    try:
+        import anthropic
+    except ImportError:
+        raise SystemExit("Agentic mode needs the SDK: pip install anthropic")
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("Agentic mode needs ANTHROPIC_API_KEY in the environment.")
+
+    client = anthropic.Anthropic()
+    api_tools = [
+        {"name": t["name"], "description": t["description"], "input_schema": t["input_schema"]}
+        for t in tools
+    ]
+
+    results = []
+    passed = 0
+    print("\n" + "=" * 70)
+    print(f"AGENTIC TOOL-SELECTION EVALUATION  (model={model})")
+    print("=" * 70)
+    for task in tasks:
+        msg = client.messages.create(
+            model=model,
+            max_tokens=512,
+            tools=api_tools,
+            tool_choice={"type": "auto"},
+            messages=[{"role": "user", "content": task["prompt"]}],
+        )
+        chosen = next((b.name for b in msg.content if getattr(b, "type", "") == "tool_use"), None)
+        ok = chosen in task["expected"]
+        passed += int(ok)
+        results.append(
+            {"task": task["id"], "chosen": chosen, "expected": sorted(task["expected"]), "pass": ok}
+        )
+        mark = "PASS" if ok else "FAIL"
+        print(
+            f"   [{mark}] {task['id']:<28} chose={chosen!s:<28} expected={sorted(task['expected'])}"
+        )
+
+    accuracy = passed / max(1, len(tasks))
+    print(f"\nTool-selection accuracy: {passed}/{len(tasks)} = {accuracy:.0%}")
+    return {
+        "model": model,
+        "accuracy": accuracy,
+        "passed": passed,
+        "total": len(tasks),
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate the KINTSUGI MCP tool surface.")
+    parser.add_argument(
+        "--agentic",
+        action="store_true",
+        help="Run the live tool-selection eval (needs ANTHROPIC_API_KEY).",
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Model (default: {DEFAULT_MODEL}).")
+    parser.add_argument("--json", metavar="PATH", help="Write the full report as JSON.")
+    args = parser.parse_args(argv)
+
+    tools = load_tools()
+    report: dict[str, Any] = {"structural": run_structural(tools, TASKS)}
+    if args.agentic:
+        report["agentic"] = run_agentic(tools, TASKS, args.model)
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote report to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/mcp/tasks.py
+++ b/evals/mcp/tasks.py
@@ -1,0 +1,126 @@
+"""Realistic tool-selection tasks for the KINTSUGI MCP evaluation harness.
+
+Each task is a natural-language request a scientist might make to Claude while
+driving the MCP server. ``expected`` is the set of *acceptable* first tool calls
+(more than one is allowed where genuinely ambiguous). Several tasks are
+deliberately chosen to probe confusable pairs on the 26-tool surface
+(``denoise`` vs ``denoise_advanced``; the three background-removal tools;
+``assess_quality`` vs ``compute_snr``; the learning-recall vs record tools).
+
+Keeping these as plain data (no MCP/anthropic import) lets the harness load them
+in any environment.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class EvalTask(TypedDict):
+    id: str
+    prompt: str
+    expected: set[str]
+    rationale: str
+
+
+TASKS: list[EvalTask] = [
+    {
+        "id": "load_channel",
+        "prompt": "Load the CD8 channel from cycle 2 of my project at /data/proj.",
+        "expected": {"load_channel"},
+        "rationale": "Direct load request with project/cycle/channel.",
+    },
+    {
+        "id": "list_channels",
+        "prompt": "What channels are available in cycle 1 of the project at /data/proj?",
+        "expected": {"list_channels"},
+        "rationale": "Enumerate available channels for a project/cycle.",
+    },
+    {
+        "id": "quality",
+        "prompt": "How good is the CD3 channel I just loaded? Give me a quality score and SNR.",
+        "expected": {"assess_quality", "compute_snr"},
+        "rationale": "Quality assessment; assess_quality is the richer answer, compute_snr acceptable.",
+    },
+    {
+        "id": "subtract_blank_global",
+        "prompt": "Remove the autofluorescence from my loaded CD20 channel using the Blank channel.",
+        "expected": {"subtract_blank"},
+        "rationale": "Blank-channel AF subtraction with a paired blank.",
+    },
+    {
+        "id": "analyze_weighted_preview",
+        "prompt": (
+            "Before applying anything, show me the per-intensity-range weights you would use "
+            "for weighted autofluorescence subtraction of CD20 against the Blank channel."
+        ),
+        "expected": {"analyze_weighted_subtraction"},
+        "rationale": "Preview-only request (verification-first); must NOT call subtract_blank yet.",
+    },
+    {
+        "id": "denoise_auto",
+        "prompt": "This channel is really noisy. Automatically pick the best denoiser and clean it up.",
+        "expected": {"denoise_advanced"},
+        "rationale": "Auto/adaptive denoising = denoise_advanced, NOT the basic denoise tool.",
+    },
+    {
+        "id": "denoise_basic",
+        "prompt": "Just apply a simple median filter to smooth the loaded channel.",
+        "expected": {"denoise"},
+        "rationale": "Explicit simple median filter = basic denoise, NOT denoise_advanced.",
+    },
+    {
+        "id": "estimate_background_no_blank",
+        "prompt": "I don't have a blank channel. Estimate and subtract the background automatically.",
+        "expected": {"estimate_background"},
+        "rationale": "Parameter-free, blank-free background removal = estimate_background (SMO).",
+    },
+    {
+        "id": "gaussian_subtract",
+        "prompt": "Remove the smooth structured background by subtracting a Gaussian-blurred version.",
+        "expected": {"gaussian_subtract"},
+        "rationale": "Explicit Gaussian-blur subtraction.",
+    },
+    {
+        "id": "thumbnail",
+        "prompt": "Show me a small downsampled preview image of the loaded DAPI channel.",
+        "expected": {"get_thumbnail"},
+        "rationale": "Visual preview = thumbnail (not get_image_stats).",
+    },
+    {
+        "id": "learned_recall",
+        "prompt": "What blank-subtraction parameters worked before for CD3 in tonsil tissue?",
+        "expected": {"get_learned_parameters", "suggest_with_learning"},
+        "rationale": "Recall learned history by tissue/marker/operation.",
+    },
+    {
+        "id": "record_success",
+        "prompt": (
+            "That result looks great. Record these blank-subtraction parameters so we reuse "
+            "them next time for CD3 in tonsil."
+        ),
+        "expected": {"record_successful_parameters", "approve_and_learn"},
+        "rationale": "Persist approved params to the learning DB.",
+    },
+    {
+        "id": "cluster",
+        "prompt": "Group my channels so I only have to tune parameters once per similar group.",
+        "expected": {"cluster_channels"},
+        "rationale": "Feature-similarity clustering of channels.",
+    },
+    {
+        "id": "optimize",
+        "prompt": (
+            "Automatically search for the best autofluorescence-subtraction parameters for CD8 "
+            "vs Blank. I don't want to adjust sliders by hand."
+        ),
+        "expected": {"optimize_parameters"},
+        "rationale": "Automated parameter search (Optuna) = optimize_parameters.",
+    },
+    {
+        "id": "save",
+        "prompt": "Save the processed CD8 channel as an OME-TIFF.",
+        "expected": {"save_processed"},
+        "rationale": "Persist a processed channel to disk.",
+    },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,10 @@ bio = [
 
 # Claude Code MCP integration
 claude = [
-    "mcp>=1.0.0",
+    # >=1.10 is required for structured tool output (Tool.outputSchema /
+    # CallToolResult.structuredContent / FastMCP structured_output), which the
+    # server relies on. <2 guards against the next major SDK revision.
+    "mcp>=1.10.0,<2",
     "httpx>=0.27.0",
     "optuna>=3.0",
     "smo>=0.7",
@@ -191,6 +194,9 @@ dev = [
     "pytest-asyncio>=0.23.0,<1.0",
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.3.0",
+    # MCP stack so the MCP server/tool tests can construct the FastMCP server
+    # and exercise the protocol (tools/list, tools/call, structured output).
+    "mcp>=1.10.0,<2",
     "black==26.1.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",

--- a/src/kintsugi/cli.py
+++ b/src/kintsugi/cli.py
@@ -932,43 +932,19 @@ def start():
 @mcp.command()
 def tools():
     """List available MCP tools."""
+    from kintsugi.mcp.tool_specs import TOOL_SPECS
+
     table = Table(title="KINTSUGI MCP Tools")
     table.add_column("Tool", style="cyan")
     table.add_column("Description", style="white")
 
-    tool_list = [
-        # Signal Isolation
-        ("load_channel", "Load a channel image from a KINTSUGI project"),
-        ("subtract_blank", "Subtract autofluorescence/blank channel from signal"),
-        ("denoise", "Apply denoising filters (percentile, uniform, median)"),
-        ("denoise_advanced", "Advanced denoising (N2V, NLM, BM3D, bilateral, adaptive)"),
-        ("apply_clahe", "Apply Contrast Limited Adaptive Histogram Equalization"),
-        ("clean_background", "Remove background and small objects"),
-        ("gaussian_subtract", "Subtract Gaussian-blurred version for background removal"),
-        # Quality Assessment
-        ("assess_quality", "Assess channel quality using DL/heuristic metrics"),
-        ("compute_snr", "Compute Signal-to-Noise Ratio"),
-        # Visualization
-        ("get_image_stats", "Get statistics for a loaded image"),
-        ("get_thumbnail", "Get a downsampled thumbnail for preview"),
-        # Workflow
-        ("list_channels", "List available channels in the project"),
-        ("save_processed", "Save processed channel to output directory"),
-        ("suggest_parameters", "Analyze channel and suggest processing parameters"),
-        ("generate_jupyter_cell", "Generate Jupyter cell for interactive tuning"),
-        # Parameter Learning
-        ("get_learned_parameters", "Get recommended params from tissue/marker history"),
-        ("record_successful_parameters", "Record approved params for future learning"),
-        ("suggest_with_learning", "Get suggestions combining analysis + learned history"),
-        ("approve_and_learn", "Approve results and record all params for learning"),
-        ("get_learning_statistics", "Get statistics about the learning database"),
-    ]
-
-    for name, desc in tool_list:
-        table.add_row(name, desc)
+    for spec in TOOL_SPECS:
+        table.add_row(spec["name"], spec["description"])
 
     console.print(table)
-    console.print("\n[dim]Use 'kintsugi mcp start' to start the server[/dim]")
+    console.print(
+        f"\n[dim]{len(TOOL_SPECS)} tools. Use 'kintsugi mcp start' to start the server.[/dim]"
+    )
     console.print("[dim]Learning tools remember successful parameters by tissue/marker[/dim]")
 
 

--- a/src/kintsugi/deps.py
+++ b/src/kintsugi/deps.py
@@ -104,12 +104,14 @@ OPTIONAL_GROUPS = {
     "claude": {
         "description": "Claude Code MCP integration",
         "packages": ["mcp", "httpx"],
-        "install_cmd": "pip install mcp httpx",
+        # mcp>=1.10 is required for FastMCP structured tool output (see pyproject
+        # claude extra); quote the spec so the shell does not treat < as redirect.
+        "install_cmd": "pip install 'mcp>=1.10.0,<2' httpx",
     },
     "dev": {
         "description": "Development tools (pytest, ruff, black, mypy)",
-        "packages": ["pytest", "ruff", "black", "mypy", "pre_commit"],
-        "install_cmd": "pip install pytest pytest-asyncio pytest-cov pytest-xdist ruff black mypy pre-commit commitizen",
+        "packages": ["pytest", "ruff", "black", "mypy", "pre_commit", "mcp"],
+        "install_cmd": "pip install pytest pytest-asyncio pytest-cov pytest-xdist 'mcp>=1.10.0,<2' ruff black mypy pre-commit commitizen",
     },
     "docs": {
         "description": "Documentation (Sphinx)",

--- a/src/kintsugi/mcp/server.py
+++ b/src/kintsugi/mcp/server.py
@@ -1,26 +1,31 @@
 """
 KINTSUGI MCP Server
 
-Exposes image processing tools for Claude Code integration.
+Exposes image processing tools for Claude Code integration, built on the
+high-level FastMCP server from the official ``mcp`` SDK.
+
+Each tool returns a plain ``dict`` which FastMCP emits as **structured content**
+(``structuredContent``) alongside the human-readable JSON text block, so Claude
+receives machine-readable results rather than only a serialized string. The tool
+implementations live in :mod:`kintsugi.mcp.tools` and are registered from the
+declarative :data:`kintsugi.mcp.tool_specs.TOOL_SPECS` registry.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import sys
-from typing import Any
+
+from kintsugi.mcp.tool_specs import TOOL_SPECS
 
 try:
-    from mcp.server import Server
-    from mcp.server.stdio import stdio_server
-    from mcp.types import TextContent, Tool
+    from mcp.server.fastmcp import FastMCP
 
     MCP_AVAILABLE = True
 except ImportError:
     MCP_AVAILABLE = False
-    Server = None
+    FastMCP = None  # type: ignore[assignment,misc]
 
 # Configure logging. The stdio transport uses stdout for the JSON-RPC stream,
 # so all logging MUST go to stderr to avoid corrupting protocol messages.
@@ -32,842 +37,76 @@ logging.basicConfig(
 logger = logging.getLogger("kintsugi.mcp")
 
 
-# Global state for the current project/session
-_session_state: dict[str, Any] = {
-    "project_path": None,
-    "current_channel": None,
-    "loaded_images": {},
-    "processing_history": [],
-}
-
-
-def create_server() -> Server:
-    """Create and configure the KINTSUGI MCP server."""
+def create_server() -> FastMCP:
+    """Create and configure the KINTSUGI FastMCP server."""
     if not MCP_AVAILABLE:
         raise ImportError("MCP package not installed. Install with: pip install kintsugi[claude]")
 
-    server = Server("kintsugi")
-
-    # Register all tools. Despite the historical name, this single registration
-    # function declares the full tool surface (signal isolation, quality
-    # assessment, visualization, workflow, clustering, learning, and
-    # optimization) and routes calls to the appropriate handler module.
-    _register_signal_isolation_tools(server)
-
+    server = FastMCP("kintsugi")
+    _register_tools(server)
     return server
 
 
-def _register_signal_isolation_tools(server: Server):
-    """Register signal isolation tools."""
+def _register_tools(server: FastMCP) -> None:
+    """Register every tool in :data:`TOOL_SPECS` with the FastMCP server.
 
-    @server.list_tools()
-    async def list_tools() -> list[Tool]:
-        """List available tools."""
-        return [
-            # Signal Isolation Tools
-            Tool(
-                name="load_channel",
-                description="Load a channel image from a KINTSUGI project. Returns image metadata and prepares it for processing.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "project_path": {
-                            "type": "string",
-                            "description": "Path to the KINTSUGI project directory",
-                        },
-                        "cycle": {
-                            "type": "string",
-                            "description": "Cycle name or number (e.g., 'cyc001' or '1')",
-                        },
-                        "channel": {
-                            "type": "string",
-                            "description": "Channel name (e.g., 'CD3', 'DAPI')",
-                        },
-                    },
-                    "required": ["project_path", "cycle", "channel"],
-                },
-            ),
-            Tool(
-                name="subtract_blank",
-                description="Subtract autofluorescence/blank channel from signal. Uses optimized Dask operations for large images.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "signal_channel": {
-                            "type": "string",
-                            "description": "Name of loaded signal channel",
-                        },
-                        "blank_channel": {
-                            "type": "string",
-                            "description": "Name of loaded blank channel",
-                        },
-                        "blank_clip_factor": {
-                            "type": "integer",
-                            "description": "Clip blank values below this threshold to 0 (default: 0)",
-                            "default": 0,
-                        },
-                        "blank_scale_factor": {
-                            "type": "number",
-                            "description": "Scale factor for blank subtraction (default: 1.0)",
-                            "default": 1.0,
-                        },
-                        "smooth_low": {
-                            "type": "boolean",
-                            "description": "Apply smoothing to low-intensity regions",
-                            "default": False,
-                        },
-                        "smooth_high": {
-                            "type": "boolean",
-                            "description": "Apply smoothing to high-intensity regions",
-                            "default": False,
-                        },
-                        "erosion": {
-                            "type": "integer",
-                            "description": "Erosion disk size for void removal (default: 0)",
-                            "default": 0,
-                        },
-                    },
-                    "required": ["signal_channel", "blank_channel"],
-                },
-            ),
-            Tool(
-                name="denoise",
-                description="Apply denoising filters (percentile, uniform, median) to reduce noise.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel to denoise",
-                        },
-                        "method": {
-                            "type": "string",
-                            "enum": ["percentile", "uniform", "median"],
-                            "description": "Denoising method",
-                        },
-                        "filter_size": {
-                            "type": "integer",
-                            "description": "Filter kernel size (default: 3)",
-                            "default": 3,
-                        },
-                        "percentile": {
-                            "type": "integer",
-                            "description": "Percentile value for percentile filter (default: 10)",
-                            "default": 10,
-                        },
-                    },
-                    "required": ["channel", "method"],
-                },
-            ),
-            Tool(
-                name="apply_clahe",
-                description="Apply Contrast Limited Adaptive Histogram Equalization to enhance local contrast.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                        "clip_limit": {
-                            "type": "number",
-                            "description": "Clip limit for contrast limiting (default: 0.01)",
-                            "default": 0.01,
-                        },
-                        "tile_grid_size": {
-                            "type": "integer",
-                            "description": "Size of grid for histogram equalization (default: 70)",
-                            "default": 70,
-                        },
-                        "nbins": {
-                            "type": "integer",
-                            "description": "Number of histogram bins (default: 128)",
-                            "default": 128,
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="clean_background",
-                description="Remove background and small objects from the image.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                        "background_threshold": {
-                            "type": "integer",
-                            "description": "Intensity threshold below which pixels are set to 0 (default: 100)",
-                            "default": 100,
-                        },
-                        "remove_small_objects": {
-                            "type": "boolean",
-                            "description": "Whether to remove small connected components",
-                            "default": False,
-                        },
-                        "min_object_size": {
-                            "type": "integer",
-                            "description": "Minimum object size to keep (default: 30)",
-                            "default": 30,
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="gaussian_subtract",
-                description="Subtract Gaussian-blurred version to remove structured background/autofluorescence.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                        "sigma": {
-                            "type": "integer",
-                            "description": "Gaussian sigma value (default: 10)",
-                            "default": 10,
-                        },
-                        "scale_factor": {
-                            "type": "number",
-                            "description": "Scale factor for subtraction (default: 0.1)",
-                            "default": 0.1,
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="denoise_advanced",
-                description="Apply advanced denoising: adaptive (auto-select best filter), bilateral (edge-preserving), nlm (non-local means), bm3d (block matching 3D), n2v (self-supervised Noise2Void), or patch_svd.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel to denoise",
-                        },
-                        "method": {
-                            "type": "string",
-                            "enum": ["adaptive", "bilateral", "nlm", "bm3d", "n2v", "patch_svd"],
-                            "description": "Advanced denoising method (default: adaptive)",
-                            "default": "adaptive",
-                        },
-                        "strength": {
-                            "type": "string",
-                            "enum": ["light", "medium", "strong", "auto"],
-                            "description": "Denoising strength (default: auto)",
-                            "default": "auto",
-                        },
-                        "preserve_edges": {
-                            "type": "boolean",
-                            "description": "Prioritize edge preservation (default: true)",
-                            "default": True,
-                        },
-                        "n2v_epochs": {
-                            "type": "integer",
-                            "description": "Training epochs for N2V method (default: 50)",
-                            "default": 50,
-                        },
-                        "model_path": {
-                            "type": "string",
-                            "description": "Path to pre-trained N2V model (optional, skip training if provided)",
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            # Quality Assessment Tools
-            Tool(
-                name="assess_quality",
-                description="Assess channel quality using heuristic and/or deep learning metrics. Returns SNR, contrast, and confidence scores.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel to assess",
-                        },
-                        "use_dl_model": {
-                            "type": "boolean",
-                            "description": "Use deep learning model if available (default: False)",
-                            "default": False,
-                        },
-                        "confidence_threshold": {
-                            "type": "number",
-                            "description": "Threshold below which manual review is flagged (default: 0.85)",
-                            "default": 0.85,
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="compute_snr",
-                description="Compute Signal-to-Noise Ratio for a channel.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            # Visualization Tools
-            Tool(
-                name="get_image_stats",
-                description="Get statistics for a loaded image (min, max, mean, std, histogram).",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="get_thumbnail",
-                description="Get a downsampled thumbnail of the image for preview.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                        "max_size": {
-                            "type": "integer",
-                            "description": "Maximum dimension of thumbnail (default: 512)",
-                            "default": 512,
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            # Workflow Tools
-            Tool(
-                name="list_channels",
-                description="List all available channels in the current project/cycle.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "project_path": {
-                            "type": "string",
-                            "description": "Path to KINTSUGI project",
-                        },
-                        "cycle": {
-                            "type": "string",
-                            "description": "Cycle name (optional - lists all if not specified)",
-                        },
-                    },
-                    "required": ["project_path"],
-                },
-            ),
-            Tool(
-                name="save_processed",
-                description="Save the processed channel to the project output directory.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of processed channel to save",
-                        },
-                        "output_name": {
-                            "type": "string",
-                            "description": "Output filename (optional - auto-generated if not provided)",
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["tiff", "zarr", "ome-tiff"],
-                            "description": "Output format (default: tiff)",
-                            "default": "tiff",
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="get_processing_history",
-                description="Get the processing history for a channel, showing all operations applied.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of channel",
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="suggest_parameters",
-                description="Analyze channel and suggest processing parameters based on image characteristics.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                        "blank_channel": {
-                            "type": "string",
-                            "description": "Name of blank channel for AF estimation (optional)",
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-            Tool(
-                name="generate_jupyter_cell",
-                description="Generate a Jupyter notebook cell for interactive parameter tuning with Kview2 widgets.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "operation": {
-                            "type": "string",
-                            "enum": [
-                                "blank_subtraction",
-                                "denoise",
-                                "clahe",
-                                "clean",
-                                "gaussian_subtract",
-                                "full_pipeline",
-                            ],
-                            "description": "Operation to create interactive tuner for",
-                        },
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel",
-                        },
-                        "initial_params": {
-                            "type": "object",
-                            "description": "Initial parameter values (optional)",
-                        },
-                    },
-                    "required": ["operation", "channel"],
-                },
-            ),
-            # Channel Clustering Tools
-            Tool(
-                name="cluster_channels",
-                description="Cluster channels by image feature similarity. Groups channels that share similar intensity profiles, SNR, and texture so parameters can be tuned once per cluster.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "project_path": {
-                            "type": "string",
-                            "description": "Path to KINTSUGI project directory",
-                        },
-                        "n_clusters": {
-                            "type": "integer",
-                            "description": "Number of clusters (auto-select if omitted)",
-                        },
-                        "wavelength_aware": {
-                            "type": "boolean",
-                            "description": "Enforce same-wavelength clustering (default: true)",
-                            "default": True,
-                        },
-                    },
-                    "required": ["project_path"],
-                },
-            ),
-            Tool(
-                name="propagate_parameters",
-                description="Apply tuned signal isolation parameters from a representative channel to all members of a cluster.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "project_path": {
-                            "type": "string",
-                            "description": "Path to KINTSUGI project directory",
-                        },
-                        "cluster_id": {
-                            "type": "integer",
-                            "description": "Cluster ID to propagate parameters to",
-                        },
-                        "params": {
-                            "type": "object",
-                            "description": "Processing parameters (blank_params and/or clean_params dicts)",
-                        },
-                        "output_dir": {
-                            "type": "string",
-                            "description": "Output directory (default: project signal_isolated dir)",
-                        },
-                    },
-                    "required": ["project_path", "cluster_id", "params"],
-                },
-            ),
-            # Parameter Learning Tools
-            Tool(
-                name="get_learned_parameters",
-                description="Get recommended parameters based on learned history from similar tissue/marker combinations. Returns parameters with confidence scores.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "tissue_type": {
-                            "type": "string",
-                            "description": "Type of tissue (e.g., 'tonsil', 'lymph node', 'pancreas')",
-                        },
-                        "marker_name": {
-                            "type": "string",
-                            "description": "Marker name (e.g., 'CD3', 'CD20', 'DAPI')",
-                        },
-                        "operation": {
-                            "type": "string",
-                            "description": "Processing operation (e.g., 'blank_subtraction', 'denoise')",
-                        },
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path for project-specific learning (optional)",
-                        },
-                        "channel": {
-                            "type": "string",
-                            "description": "Channel name to get image characteristics from (optional)",
-                        },
-                    },
-                    "required": ["tissue_type", "marker_name", "operation"],
-                },
-            ),
-            Tool(
-                name="record_successful_parameters",
-                description="Record a successful parameter set for future learning. Call after user approves processing results.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "tissue_type": {
-                            "type": "string",
-                            "description": "Type of tissue processed",
-                        },
-                        "marker_name": {
-                            "type": "string",
-                            "description": "Marker name",
-                        },
-                        "operation": {
-                            "type": "string",
-                            "description": "Processing operation",
-                        },
-                        "parameters": {
-                            "type": "object",
-                            "description": "Parameter dictionary that was used",
-                        },
-                        "quality_before": {
-                            "type": "number",
-                            "description": "Quality score before processing",
-                            "default": 0.0,
-                        },
-                        "quality_after": {
-                            "type": "number",
-                            "description": "Quality score after processing",
-                            "default": 0.0,
-                        },
-                        "user_approved": {
-                            "type": "boolean",
-                            "description": "Whether user approved the result",
-                            "default": True,
-                        },
-                        "user_notes": {
-                            "type": "string",
-                            "description": "Optional notes from user",
-                        },
-                        "channel": {
-                            "type": "string",
-                            "description": "Channel name (for characteristics)",
-                        },
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path",
-                        },
-                    },
-                    "required": ["tissue_type", "marker_name", "operation", "parameters"],
-                },
-            ),
-            Tool(
-                name="suggest_with_learning",
-                description="Get comprehensive parameter suggestions combining image analysis AND learned history. This is the primary recommendation tool.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Loaded channel name",
-                        },
-                        "tissue_type": {
-                            "type": "string",
-                            "description": "Tissue type",
-                        },
-                        "marker_name": {
-                            "type": "string",
-                            "description": "Marker name",
-                        },
-                        "blank_channel": {
-                            "type": "string",
-                            "description": "Blank channel for AF estimation (optional)",
-                        },
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path (optional)",
-                        },
-                    },
-                    "required": ["channel", "tissue_type", "marker_name"],
-                },
-            ),
-            Tool(
-                name="approve_and_learn",
-                description="Approve processing results and record ALL parameters for learning. Call when user approves final processed result.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Channel name",
-                        },
-                        "tissue_type": {
-                            "type": "string",
-                            "description": "Tissue type",
-                        },
-                        "marker_name": {
-                            "type": "string",
-                            "description": "Marker name",
-                        },
-                        "operations_params": {
-                            "type": "object",
-                            "description": "Dict mapping operation names to their parameters",
-                        },
-                        "quality_before": {
-                            "type": "number",
-                            "description": "Quality score before all processing",
-                        },
-                        "quality_after": {
-                            "type": "number",
-                            "description": "Quality score after all processing",
-                        },
-                        "notes": {
-                            "type": "string",
-                            "description": "User notes",
-                            "default": "",
-                        },
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path",
-                        },
-                    },
-                    "required": [
-                        "channel",
-                        "tissue_type",
-                        "marker_name",
-                        "operations_params",
-                        "quality_before",
-                        "quality_after",
-                    ],
-                },
-            ),
-            Tool(
-                name="get_learning_statistics",
-                description="Get statistics about the parameter learning database.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path (optional)",
-                        },
-                    },
-                    "required": [],
-                },
-            ),
-            # Automated Optimization Tools (Tier 2)
-            Tool(
-                name="optimize_parameters",
-                description="Find optimal signal isolation parameters via Bayesian optimization (Optuna). Automatically searches the parameter space — no manual slider adjustment needed.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "signal_channel": {
-                            "type": "string",
-                            "description": "Name of loaded signal channel",
-                        },
-                        "blank_channel": {
-                            "type": "string",
-                            "description": "Name of loaded blank channel",
-                        },
-                        "n_trials": {
-                            "type": "integer",
-                            "description": "Maximum optimization trials (default: 80)",
-                            "default": 80,
-                        },
-                        "timeout": {
-                            "type": "integer",
-                            "description": "Maximum seconds for optimization (default: 300)",
-                            "default": 300,
-                        },
-                        "optimize_clean": {
-                            "type": "boolean",
-                            "description": "Also optimize background cleaning parameters (default: true)",
-                            "default": True,
-                        },
-                        "warm_start_params": {
-                            "type": "object",
-                            "description": "Initial parameter guess for faster convergence (optional)",
-                        },
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path for storing optimization study (optional)",
-                        },
-                    },
-                    "required": ["signal_channel", "blank_channel"],
-                },
-            ),
-            Tool(
-                name="predict_parameters",
-                description="Predict signal isolation parameters from image features using a trained Random Forest model. Includes confidence scores and uncertainty estimates.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "signal_channel": {
-                            "type": "string",
-                            "description": "Name of loaded signal channel",
-                        },
-                        "blank_channel": {
-                            "type": "string",
-                            "description": "Name of loaded blank channel (optional)",
-                        },
-                        "project_path": {
-                            "type": "string",
-                            "description": "Project path containing predictor model (optional)",
-                        },
-                        "model_path": {
-                            "type": "string",
-                            "description": "Explicit path to predictor model .joblib (optional)",
-                        },
-                    },
-                    "required": ["signal_channel"],
-                },
-            ),
-            Tool(
-                name="estimate_background",
-                description="Estimate and subtract background using SMO (Silver Mountain Operator). Parameter-free — no blank channel needed.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string",
-                            "description": "Name of loaded channel image",
-                        },
-                        "kernel_size": {
-                            "type": "integer",
-                            "description": "SMO kernel size (default: 7, robust across 5-15)",
-                            "default": 7,
-                        },
-                        "return_background": {
-                            "type": "boolean",
-                            "description": "Store estimated background as a loaded image (default: false)",
-                            "default": False,
-                        },
-                    },
-                    "required": ["channel"],
-                },
-            ),
-        ]
+    Tool handlers stay plain ``async`` functions in :mod:`kintsugi.mcp.tools`
+    (FastMCP-agnostic, so the unit tests can call them directly). They are
+    imported lazily here so importing this module does not pull the heavy
+    image-processing dependencies.
+    """
+    from kintsugi.mcp.tools import (
+        learning,
+        quality_assessment,
+        signal_isolation,
+        visualization,
+        workflow,
+    )
 
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-        """Handle tool calls."""
-        try:
-            # Import tool implementations
-            from kintsugi.mcp.tools import (
-                learning,
-                quality_assessment,
-                signal_isolation,
-                visualization,
-                workflow,
-            )
+    modules = {
+        "signal_isolation": signal_isolation,
+        "quality_assessment": quality_assessment,
+        "visualization": visualization,
+        "workflow": workflow,
+        "learning": learning,
+    }
 
-            # Route to appropriate handler
-            if name == "load_channel":
-                result = await signal_isolation.load_channel(**arguments)
-            elif name == "subtract_blank":
-                result = await signal_isolation.subtract_blank(**arguments)
-            elif name == "denoise":
-                result = await signal_isolation.denoise(**arguments)
-            elif name == "apply_clahe":
-                result = await signal_isolation.apply_clahe(**arguments)
-            elif name == "clean_background":
-                result = await signal_isolation.clean_background(**arguments)
-            elif name == "gaussian_subtract":
-                result = await signal_isolation.gaussian_subtract(**arguments)
-            elif name == "denoise_advanced":
-                result = await signal_isolation.denoise_advanced(**arguments)
-            elif name == "assess_quality":
-                result = await quality_assessment.assess_quality(**arguments)
-            elif name == "compute_snr":
-                result = await quality_assessment.compute_snr(**arguments)
-            elif name == "get_image_stats":
-                result = await visualization.get_image_stats(**arguments)
-            elif name == "get_thumbnail":
-                result = await visualization.get_thumbnail(**arguments)
-            elif name == "list_channels":
-                result = await workflow.list_channels(**arguments)
-            elif name == "save_processed":
-                result = await workflow.save_processed(**arguments)
-            elif name == "get_processing_history":
-                result = await workflow.get_processing_history(**arguments)
-            elif name == "suggest_parameters":
-                result = await workflow.suggest_parameters(**arguments)
-            elif name == "generate_jupyter_cell":
-                result = await workflow.generate_jupyter_cell(**arguments)
-            # Clustering tools
-            elif name == "cluster_channels":
-                result = await signal_isolation.cluster_channels_tool(**arguments)
-            elif name == "propagate_parameters":
-                result = await signal_isolation.propagate_parameters_tool(**arguments)
-            # Learning tools
-            elif name == "get_learned_parameters":
-                result = await learning.get_learned_parameters(**arguments)
-            elif name == "record_successful_parameters":
-                result = await learning.record_successful_parameters(**arguments)
-            elif name == "suggest_with_learning":
-                result = await learning.suggest_with_learning(**arguments)
-            elif name == "approve_and_learn":
-                result = await learning.approve_and_learn(**arguments)
-            elif name == "get_learning_statistics":
-                result = await learning.get_learning_statistics(**arguments)
-            # Automated optimization tools (Tier 2)
-            elif name == "optimize_parameters":
-                result = await signal_isolation.optimize_parameters(**arguments)
-            elif name == "predict_parameters":
-                result = await signal_isolation.predict_parameters(**arguments)
-            elif name == "estimate_background":
-                result = await signal_isolation.estimate_background(**arguments)
-            else:
-                result = {"error": f"Unknown tool: {name}"}
-
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        except Exception as e:
-            logger.exception(f"Error in tool {name}")
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({"error": str(e), "tool": name}, indent=2),
-                )
-            ]
-
-    return server
+    for spec in TOOL_SPECS:
+        handler = getattr(modules[spec["module"]], spec["attr"])
+        # structured_output=True makes FastMCP emit the returned dict as
+        # ``structuredContent`` (plus the JSON text block) for every tool.
+        server.add_tool(
+            handler,
+            name=spec["name"],
+            description=spec["description"],
+            structured_output=True,
+        )
+        _advertise_schema(server, spec["name"], spec["input_schema"])
 
 
-async def run_server():
+def _advertise_schema(server: FastMCP, name: str, schema: dict) -> None:
+    """Advertise the curated input schema for ``name`` verbatim.
+
+    FastMCP derives an input schema from the handler's type hints, which drops
+    the per-parameter descriptions and ``enum`` constraints the KINTSUGI tools
+    rely on. We overwrite the advertised schema with the curated one from
+    :data:`TOOL_SPECS`; argument *validation* still runs from the handler's
+    signature, so this only changes the contract clients read.
+
+    This touches a FastMCP internal (the tool manager), so it is wrapped
+    defensively: if a future ``mcp`` release changes the internals the server
+    still starts, falling back to the auto-generated schema (and the dedicated
+    test in ``tests/test_mcp_tools.py`` flags the regression).
+    """
+    try:
+        tool = server._tool_manager.get_tool(name)
+        if tool is not None:
+            tool.parameters = schema
+    except Exception as exc:  # pragma: no cover - depends on mcp internals
+        logger.warning("Could not advertise curated input schema for tool %r: %s", name, exc)
+
+
+async def run_server() -> None:
     """Run the MCP server using stdio transport."""
     if not MCP_AVAILABLE:
         print(
@@ -878,12 +117,10 @@ async def run_server():
 
     server = create_server()
     logger.info("Starting KINTSUGI MCP server...")
-
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
+    await server.run_stdio_async()
 
 
-def main():
+def main() -> None:
     """Entry point for the MCP server."""
     asyncio.run(run_server())
 

--- a/src/kintsugi/mcp/tool_specs.py
+++ b/src/kintsugi/mcp/tool_specs.py
@@ -1,0 +1,841 @@
+"""
+Declarative tool registry for the KINTSUGI MCP server.
+
+Each entry pairs a public MCP tool name with its handler (``module``/``attr`` in
+``kintsugi.mcp.tools``), a top-level ``description``, and the ``input_schema`` that
+is advertised to clients verbatim. Keeping this as plain data (no ``mcp`` import)
+lets ``kintsugi mcp tools`` and tests read the registry without the optional
+``[claude]`` dependency installed.
+
+The input schemas preserve the per-parameter descriptions and ``enum`` constraints
+that FastMCP's signature-derived schemas would otherwise drop. Argument *validation*
+still runs from each handler's function signature (types) plus the semantic
+``path_safety`` checks inside the handler body; this schema is the contract clients
+read when deciding how to call a tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# name -> (handler module, handler attr, description, advertised input schema)
+TOOL_SPECS: list[dict[str, Any]] = [
+    # ---- Signal Isolation ----
+    {
+        "name": "load_channel",
+        "module": "signal_isolation",
+        "attr": "load_channel",
+        "description": (
+            "Load a channel image from a KINTSUGI project. Returns image metadata "
+            "and prepares it for processing."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to the KINTSUGI project directory",
+                },
+                "cycle": {
+                    "type": "string",
+                    "description": "Cycle name or number (e.g., 'cyc001' or '1')",
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "Channel name (e.g., 'CD3', 'DAPI')",
+                },
+            },
+            "required": ["project_path", "cycle", "channel"],
+        },
+    },
+    {
+        "name": "subtract_blank",
+        "module": "signal_isolation",
+        "attr": "subtract_blank",
+        "description": (
+            "Subtract autofluorescence/blank channel from signal. Uses optimized "
+            "Dask operations for large images."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "signal_channel": {
+                    "type": "string",
+                    "description": "Name of loaded signal channel",
+                },
+                "blank_channel": {
+                    "type": "string",
+                    "description": "Name of loaded blank channel",
+                },
+                "blank_clip_factor": {
+                    "type": "integer",
+                    "description": "Clip blank values below this threshold to 0 (default: 0)",
+                    "default": 0,
+                },
+                "blank_scale_factor": {
+                    "type": "number",
+                    "description": "Scale factor for blank subtraction (default: 1.0)",
+                    "default": 1.0,
+                },
+                "smooth_low": {
+                    "type": "boolean",
+                    "description": "Apply smoothing to low-intensity regions",
+                    "default": False,
+                },
+                "smooth_high": {
+                    "type": "boolean",
+                    "description": "Apply smoothing to high-intensity regions",
+                    "default": False,
+                },
+                "erosion": {
+                    "type": "integer",
+                    "description": "Erosion disk size for void removal (default: 0)",
+                    "default": 0,
+                },
+            },
+            "required": ["signal_channel", "blank_channel"],
+        },
+    },
+    {
+        "name": "denoise",
+        "module": "signal_isolation",
+        "attr": "denoise",
+        "description": "Apply denoising filters (percentile, uniform, median) to reduce noise.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel to denoise",
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ["percentile", "uniform", "median"],
+                    "description": "Denoising method",
+                },
+                "filter_size": {
+                    "type": "integer",
+                    "description": "Filter kernel size (default: 3)",
+                    "default": 3,
+                },
+                "percentile": {
+                    "type": "integer",
+                    "description": "Percentile value for percentile filter (default: 10)",
+                    "default": 10,
+                },
+            },
+            "required": ["channel", "method"],
+        },
+    },
+    {
+        "name": "apply_clahe",
+        "module": "signal_isolation",
+        "attr": "apply_clahe",
+        "description": (
+            "Apply Contrast Limited Adaptive Histogram Equalization to enhance local contrast."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+                "clip_limit": {
+                    "type": "number",
+                    "description": "Clip limit for contrast limiting (default: 0.01)",
+                    "default": 0.01,
+                },
+                "tile_grid_size": {
+                    "type": "integer",
+                    "description": "Size of grid for histogram equalization (default: 70)",
+                    "default": 70,
+                },
+                "nbins": {
+                    "type": "integer",
+                    "description": "Number of histogram bins (default: 128)",
+                    "default": 128,
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "clean_background",
+        "module": "signal_isolation",
+        "attr": "clean_background",
+        "description": "Remove background and small objects from the image.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+                "background_threshold": {
+                    "type": "integer",
+                    "description": "Intensity threshold below which pixels are set to 0 (default: 100)",
+                    "default": 100,
+                },
+                "remove_small_objects": {
+                    "type": "boolean",
+                    "description": "Whether to remove small connected components",
+                    "default": False,
+                },
+                "min_object_size": {
+                    "type": "integer",
+                    "description": "Minimum object size to keep (default: 30)",
+                    "default": 30,
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "gaussian_subtract",
+        "module": "signal_isolation",
+        "attr": "gaussian_subtract",
+        "description": (
+            "Subtract Gaussian-blurred version to remove structured background/autofluorescence."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+                "sigma": {
+                    "type": "integer",
+                    "description": "Gaussian sigma value (default: 10)",
+                    "default": 10,
+                },
+                "scale_factor": {
+                    "type": "number",
+                    "description": "Scale factor for subtraction (default: 0.1)",
+                    "default": 0.1,
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "denoise_advanced",
+        "module": "signal_isolation",
+        "attr": "denoise_advanced",
+        "description": (
+            "Apply advanced denoising: adaptive (auto-select best filter), bilateral "
+            "(edge-preserving), nlm (non-local means), bm3d (block matching 3D), n2v "
+            "(self-supervised Noise2Void), or patch_svd."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel to denoise",
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ["adaptive", "bilateral", "nlm", "bm3d", "n2v", "patch_svd"],
+                    "description": "Advanced denoising method (default: adaptive)",
+                    "default": "adaptive",
+                },
+                "strength": {
+                    "type": "string",
+                    "enum": ["light", "medium", "strong", "auto"],
+                    "description": "Denoising strength (default: auto)",
+                    "default": "auto",
+                },
+                "preserve_edges": {
+                    "type": "boolean",
+                    "description": "Prioritize edge preservation (default: true)",
+                    "default": True,
+                },
+                "n2v_epochs": {
+                    "type": "integer",
+                    "description": "Training epochs for N2V method (default: 50)",
+                    "default": 50,
+                },
+                "model_path": {
+                    "type": "string",
+                    "description": "Path to pre-trained N2V model (optional, skip training if provided)",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    # ---- Quality Assessment ----
+    {
+        "name": "assess_quality",
+        "module": "quality_assessment",
+        "attr": "assess_quality",
+        "description": (
+            "Assess channel quality using heuristic and/or deep learning metrics. "
+            "Returns SNR, contrast, and confidence scores."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel to assess",
+                },
+                "use_dl_model": {
+                    "type": "boolean",
+                    "description": "Use deep learning model if available (default: False)",
+                    "default": False,
+                },
+                "confidence_threshold": {
+                    "type": "number",
+                    "description": "Threshold below which manual review is flagged (default: 0.85)",
+                    "default": 0.85,
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "compute_snr",
+        "module": "quality_assessment",
+        "attr": "compute_snr",
+        "description": "Compute Signal-to-Noise Ratio for a channel.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    # ---- Visualization ----
+    {
+        "name": "get_image_stats",
+        "module": "visualization",
+        "attr": "get_image_stats",
+        "description": "Get statistics for a loaded image (min, max, mean, std, histogram).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "get_thumbnail",
+        "module": "visualization",
+        "attr": "get_thumbnail",
+        "description": "Get a downsampled thumbnail of the image for preview.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+                "max_size": {
+                    "type": "integer",
+                    "description": "Maximum dimension of thumbnail (default: 512)",
+                    "default": 512,
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    # ---- Workflow ----
+    {
+        "name": "list_channels",
+        "module": "workflow",
+        "attr": "list_channels",
+        "description": "List all available channels in the current project/cycle.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to KINTSUGI project",
+                },
+                "cycle": {
+                    "type": "string",
+                    "description": "Cycle name (optional - lists all if not specified)",
+                },
+            },
+            "required": ["project_path"],
+        },
+    },
+    {
+        "name": "save_processed",
+        "module": "workflow",
+        "attr": "save_processed",
+        "description": "Save the processed channel to the project output directory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of processed channel to save",
+                },
+                "output_name": {
+                    "type": "string",
+                    "description": "Output filename (optional - auto-generated if not provided)",
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["tiff", "zarr", "ome-tiff"],
+                    "description": "Output format (default: tiff)",
+                    "default": "tiff",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "get_processing_history",
+        "module": "workflow",
+        "attr": "get_processing_history",
+        "description": (
+            "Get the processing history for a channel, showing all operations applied."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of channel",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "suggest_parameters",
+        "module": "workflow",
+        "attr": "suggest_parameters",
+        "description": (
+            "Analyze channel and suggest processing parameters based on image characteristics."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+                "blank_channel": {
+                    "type": "string",
+                    "description": "Name of blank channel for AF estimation (optional)",
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+    {
+        "name": "generate_jupyter_cell",
+        "module": "workflow",
+        "attr": "generate_jupyter_cell",
+        "description": (
+            "Generate a Jupyter notebook cell for interactive parameter tuning with Kview2 widgets."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "blank_subtraction",
+                        "denoise",
+                        "clahe",
+                        "clean",
+                        "gaussian_subtract",
+                        "full_pipeline",
+                    ],
+                    "description": "Operation to create interactive tuner for",
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel",
+                },
+                "initial_params": {
+                    "type": "object",
+                    "description": "Initial parameter values (optional)",
+                },
+            },
+            "required": ["operation", "channel"],
+        },
+    },
+    # ---- Channel Clustering ----
+    {
+        "name": "cluster_channels",
+        "module": "signal_isolation",
+        "attr": "cluster_channels_tool",
+        "description": (
+            "Cluster channels by image feature similarity. Groups channels that share "
+            "similar intensity profiles, SNR, and texture so parameters can be tuned "
+            "once per cluster."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to KINTSUGI project directory",
+                },
+                "n_clusters": {
+                    "type": "integer",
+                    "description": "Number of clusters (auto-select if omitted)",
+                },
+                "wavelength_aware": {
+                    "type": "boolean",
+                    "description": "Enforce same-wavelength clustering (default: true)",
+                    "default": True,
+                },
+            },
+            "required": ["project_path"],
+        },
+    },
+    {
+        "name": "propagate_parameters",
+        "module": "signal_isolation",
+        "attr": "propagate_parameters_tool",
+        "description": (
+            "Apply tuned signal isolation parameters from a representative channel to all "
+            "members of a cluster."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to KINTSUGI project directory",
+                },
+                "cluster_id": {
+                    "type": "integer",
+                    "description": "Cluster ID to propagate parameters to",
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Processing parameters (blank_params and/or clean_params dicts)",
+                },
+                "output_dir": {
+                    "type": "string",
+                    "description": "Output directory (default: project signal_isolated dir)",
+                },
+            },
+            "required": ["project_path", "cluster_id", "params"],
+        },
+    },
+    # ---- Parameter Learning ----
+    {
+        "name": "get_learned_parameters",
+        "module": "learning",
+        "attr": "get_learned_parameters",
+        "description": (
+            "Get recommended parameters based on learned history from similar tissue/marker "
+            "combinations. Returns parameters with confidence scores."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "tissue_type": {
+                    "type": "string",
+                    "description": "Type of tissue (e.g., 'tonsil', 'lymph node', 'pancreas')",
+                },
+                "marker_name": {
+                    "type": "string",
+                    "description": "Marker name (e.g., 'CD3', 'CD20', 'DAPI')",
+                },
+                "operation": {
+                    "type": "string",
+                    "description": "Processing operation (e.g., 'blank_subtraction', 'denoise')",
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path for project-specific learning (optional)",
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "Channel name to get image characteristics from (optional)",
+                },
+            },
+            "required": ["tissue_type", "marker_name", "operation"],
+        },
+    },
+    {
+        "name": "record_successful_parameters",
+        "module": "learning",
+        "attr": "record_successful_parameters",
+        "description": (
+            "Record a successful parameter set for future learning. Call after user approves "
+            "processing results."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "tissue_type": {
+                    "type": "string",
+                    "description": "Type of tissue processed",
+                },
+                "marker_name": {
+                    "type": "string",
+                    "description": "Marker name",
+                },
+                "operation": {
+                    "type": "string",
+                    "description": "Processing operation",
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "Parameter dictionary that was used",
+                },
+                "quality_before": {
+                    "type": "number",
+                    "description": "Quality score before processing",
+                    "default": 0.0,
+                },
+                "quality_after": {
+                    "type": "number",
+                    "description": "Quality score after processing",
+                    "default": 0.0,
+                },
+                "user_approved": {
+                    "type": "boolean",
+                    "description": "Whether user approved the result",
+                    "default": True,
+                },
+                "user_notes": {
+                    "type": "string",
+                    "description": "Optional notes from user",
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "Channel name (for characteristics)",
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path",
+                },
+            },
+            "required": ["tissue_type", "marker_name", "operation", "parameters"],
+        },
+    },
+    {
+        "name": "suggest_with_learning",
+        "module": "learning",
+        "attr": "suggest_with_learning",
+        "description": (
+            "Get comprehensive parameter suggestions combining image analysis AND learned "
+            "history. This is the primary recommendation tool."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Loaded channel name",
+                },
+                "tissue_type": {
+                    "type": "string",
+                    "description": "Tissue type",
+                },
+                "marker_name": {
+                    "type": "string",
+                    "description": "Marker name",
+                },
+                "blank_channel": {
+                    "type": "string",
+                    "description": "Blank channel for AF estimation (optional)",
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path (optional)",
+                },
+            },
+            "required": ["channel", "tissue_type", "marker_name"],
+        },
+    },
+    {
+        "name": "approve_and_learn",
+        "module": "learning",
+        "attr": "approve_and_learn",
+        "description": (
+            "Approve processing results and record ALL parameters for learning. Call when "
+            "user approves final processed result."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Channel name",
+                },
+                "tissue_type": {
+                    "type": "string",
+                    "description": "Tissue type",
+                },
+                "marker_name": {
+                    "type": "string",
+                    "description": "Marker name",
+                },
+                "operations_params": {
+                    "type": "object",
+                    "description": "Dict mapping operation names to their parameters",
+                },
+                "quality_before": {
+                    "type": "number",
+                    "description": "Quality score before all processing",
+                },
+                "quality_after": {
+                    "type": "number",
+                    "description": "Quality score after all processing",
+                },
+                "notes": {
+                    "type": "string",
+                    "description": "User notes",
+                    "default": "",
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path",
+                },
+            },
+            "required": [
+                "channel",
+                "tissue_type",
+                "marker_name",
+                "operations_params",
+                "quality_before",
+                "quality_after",
+            ],
+        },
+    },
+    {
+        "name": "get_learning_statistics",
+        "module": "learning",
+        "attr": "get_learning_statistics",
+        "description": "Get statistics about the parameter learning database.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path (optional)",
+                },
+            },
+            "required": [],
+        },
+    },
+    # ---- Automated Optimization (Tier 2) ----
+    {
+        "name": "optimize_parameters",
+        "module": "signal_isolation",
+        "attr": "optimize_parameters",
+        "description": (
+            "Find optimal signal isolation parameters via Bayesian optimization (Optuna). "
+            "Automatically searches the parameter space — no manual slider adjustment needed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "signal_channel": {
+                    "type": "string",
+                    "description": "Name of loaded signal channel",
+                },
+                "blank_channel": {
+                    "type": "string",
+                    "description": "Name of loaded blank channel",
+                },
+                "n_trials": {
+                    "type": "integer",
+                    "description": "Maximum optimization trials (default: 80)",
+                    "default": 80,
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Maximum seconds for optimization (default: 300)",
+                    "default": 300,
+                },
+                "optimize_clean": {
+                    "type": "boolean",
+                    "description": "Also optimize background cleaning parameters (default: true)",
+                    "default": True,
+                },
+                "warm_start_params": {
+                    "type": "object",
+                    "description": "Initial parameter guess for faster convergence (optional)",
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path for storing optimization study (optional)",
+                },
+            },
+            "required": ["signal_channel", "blank_channel"],
+        },
+    },
+    {
+        "name": "predict_parameters",
+        "module": "signal_isolation",
+        "attr": "predict_parameters",
+        "description": (
+            "Predict signal isolation parameters from image features using a trained Random "
+            "Forest model. Includes confidence scores and uncertainty estimates."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "signal_channel": {
+                    "type": "string",
+                    "description": "Name of loaded signal channel",
+                },
+                "blank_channel": {
+                    "type": "string",
+                    "description": "Name of loaded blank channel (optional)",
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Project path containing predictor model (optional)",
+                },
+                "model_path": {
+                    "type": "string",
+                    "description": "Explicit path to predictor model .joblib (optional)",
+                },
+            },
+            "required": ["signal_channel"],
+        },
+    },
+    {
+        "name": "estimate_background",
+        "module": "signal_isolation",
+        "attr": "estimate_background",
+        "description": (
+            "Estimate and subtract background using SMO (Silver Mountain Operator). "
+            "Parameter-free — no blank channel needed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Name of loaded channel image",
+                },
+                "kernel_size": {
+                    "type": "integer",
+                    "description": "SMO kernel size (default: 7, robust across 5-15)",
+                    "default": 7,
+                },
+                "return_background": {
+                    "type": "boolean",
+                    "description": "Store estimated background as a loaded image (default: false)",
+                    "default": False,
+                },
+            },
+            "required": ["channel"],
+        },
+    },
+]

--- a/src/kintsugi/mcp/tool_specs.py
+++ b/src/kintsugi/mcp/tool_specs.py
@@ -97,6 +97,49 @@ TOOL_SPECS: list[dict[str, Any]] = [
         },
     },
     {
+        "name": "analyze_weighted_subtraction",
+        "module": "signal_isolation",
+        "attr": "analyze_weighted_subtraction",
+        "description": (
+            "Preview the per-intensity-range weights for weighted autofluorescence "
+            "subtraction WITHOUT applying it. Use this to verify the plan before calling "
+            "subtract_blank with method='weighted'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "signal_channel": {
+                    "type": "string",
+                    "description": "Name of loaded signal channel",
+                },
+                "blank_channel": {
+                    "type": "string",
+                    "description": "Name of loaded blank channel",
+                },
+                "n_ranges": {
+                    "type": "integer",
+                    "description": "Number of intensity ranges (default: 5)",
+                    "default": 5,
+                },
+                "range_method": {
+                    "type": "string",
+                    "enum": ["percentile", "otsu"],
+                    "description": "Range boundary method (default: percentile)",
+                    "default": "percentile",
+                },
+                "tissue_type": {
+                    "type": "string",
+                    "description": "Tissue type for context (optional)",
+                },
+                "marker_name": {
+                    "type": "string",
+                    "description": "Marker name for context (optional)",
+                },
+            },
+            "required": ["signal_channel", "blank_channel"],
+        },
+    },
+    {
         "name": "denoise",
         "module": "signal_isolation",
         "attr": "denoise",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -30,6 +30,42 @@ HAS_DASK_IMAGE = importlib.util.find_spec("dask_image") is not None
 requires_zarr = pytest.mark.skipif(not HAS_ZARR, reason="zarr not installed")
 requires_dask_image = pytest.mark.skipif(not HAS_DASK_IMAGE, reason="dask_image not installed")
 
+try:
+    from kintsugi.mcp.server import MCP_AVAILABLE
+except Exception:  # pragma: no cover - server import should not fail
+    MCP_AVAILABLE = False
+requires_mcp = pytest.mark.skipif(not MCP_AVAILABLE, reason="mcp package not installed")
+
+# The full public MCP tool surface (kept in sync with kintsugi.mcp.tool_specs).
+EXPECTED_TOOL_NAMES = {
+    "load_channel",
+    "subtract_blank",
+    "denoise",
+    "apply_clahe",
+    "clean_background",
+    "gaussian_subtract",
+    "denoise_advanced",
+    "assess_quality",
+    "compute_snr",
+    "get_image_stats",
+    "get_thumbnail",
+    "list_channels",
+    "save_processed",
+    "get_processing_history",
+    "suggest_parameters",
+    "generate_jupyter_cell",
+    "cluster_channels",
+    "propagate_parameters",
+    "get_learned_parameters",
+    "record_successful_parameters",
+    "suggest_with_learning",
+    "approve_and_learn",
+    "get_learning_statistics",
+    "optimize_parameters",
+    "predict_parameters",
+    "estimate_background",
+}
+
 
 # =============================================================================
 # Test Fixtures
@@ -1148,35 +1184,80 @@ class TestMCPServer:
             # Restore original value
             server.MCP_AVAILABLE = original_mcp_available
 
-    def test_tool_routing(self):
-        """Test that all tools are properly routed."""
-        # This test verifies the tool routing in server.py
-        expected_tools = [
-            "load_channel",
-            "subtract_blank",
-            "denoise",
-            "apply_clahe",
-            "clean_background",
-            "gaussian_subtract",
-            "denoise_advanced",
-            "assess_quality",
-            "compute_snr",
-            "get_image_stats",
-            "get_thumbnail",
-            "list_channels",
-            "save_processed",
-            "get_processing_history",
-            "suggest_parameters",
-            "generate_jupyter_cell",
-            "get_learned_parameters",
-            "record_successful_parameters",
-            "suggest_with_learning",
-            "approve_and_learn",
-            "get_learning_statistics",
-        ]
+    def test_tool_registry_complete(self):
+        """Every advertised tool resolves to an importable coroutine handler."""
+        import importlib
+        import inspect
 
-        # Verify count matches expected
-        assert len(expected_tools) == 21
+        from kintsugi.mcp import tool_specs
+
+        names = [spec["name"] for spec in tool_specs.TOOL_SPECS]
+        # Names are unique and cover the full public surface.
+        assert len(names) == len(set(names))
+        assert set(names) == EXPECTED_TOOL_NAMES
+
+        # Each spec points at a real async handler in kintsugi.mcp.tools.
+        for spec in tool_specs.TOOL_SPECS:
+            module = importlib.import_module(f"kintsugi.mcp.tools.{spec['module']}")
+            handler = getattr(module, spec["attr"])
+            assert inspect.iscoroutinefunction(handler), spec["name"]
+            assert isinstance(spec["input_schema"], dict)
+
+
+# =============================================================================
+# Structured Output Tests (FastMCP server)
+# =============================================================================
+
+
+@requires_mcp
+class TestStructuredOutput:
+    """The FastMCP server advertises curated schemas and emits structured content."""
+
+    async def test_all_tools_registered_with_output_schema(self):
+        """Every tool is registered and declares an output schema."""
+        from kintsugi.mcp.server import create_server
+
+        server = create_server()
+        tools = await server.list_tools()
+
+        assert {t.name for t in tools} == EXPECTED_TOOL_NAMES
+        for tool in tools:
+            assert tool.outputSchema is not None, f"{tool.name} missing outputSchema"
+
+    async def test_curated_input_schema_advertised(self):
+        """The curated input schema (enums + descriptions) is advertised verbatim."""
+        from kintsugi.mcp.server import create_server
+
+        server = create_server()
+        tools = {t.name: t for t in await server.list_tools()}
+
+        # enum constraint preserved (FastMCP's signature-derived schema would drop it)
+        method = tools["denoise"].inputSchema["properties"]["method"]
+        assert method.get("enum") == ["percentile", "uniform", "median"]
+        # per-parameter description preserved
+        channel = tools["load_channel"].inputSchema["properties"]["channel"]
+        assert "description" in channel
+
+    async def test_call_returns_structured_content(self):
+        """A tool call returns structuredContent plus a human-readable text block."""
+        from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+        from kintsugi.mcp.server import create_server
+
+        server = create_server()
+        async with connect(server._mcp_server) as client:
+            result = await client.call_tool("get_processing_history", {"channel": "nope"})
+
+        assert result.isError is False
+        assert result.structuredContent == {
+            "status": "success",
+            "channel": "nope",
+            "steps": [],
+            "total_steps": 0,
+            "source_metadata": {},
+        }
+        # Backward-compatible text block is still present.
+        assert result.content and result.content[0].type == "text"
 
 
 # =============================================================================

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -38,6 +38,7 @@ requires_mcp = pytest.mark.skipif(not MCP_AVAILABLE, reason="mcp package not ins
 EXPECTED_TOOL_NAMES = {
     "load_channel",
     "subtract_blank",
+    "analyze_weighted_subtraction",
     "denoise",
     "apply_clahe",
     "clean_background",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -22,6 +22,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from kintsugi.mcp.server import MCP_AVAILABLE
+
 # Check for optional dependencies using importlib
 HAS_ZARR = importlib.util.find_spec("zarr") is not None
 HAS_DASK_IMAGE = importlib.util.find_spec("dask_image") is not None
@@ -30,10 +32,6 @@ HAS_DASK_IMAGE = importlib.util.find_spec("dask_image") is not None
 requires_zarr = pytest.mark.skipif(not HAS_ZARR, reason="zarr not installed")
 requires_dask_image = pytest.mark.skipif(not HAS_DASK_IMAGE, reason="dask_image not installed")
 
-try:
-    from kintsugi.mcp.server import MCP_AVAILABLE
-except Exception:  # pragma: no cover - server import should not fail
-    MCP_AVAILABLE = False
 requires_mcp = pytest.mark.skipif(not MCP_AVAILABLE, reason="mcp package not installed")
 
 # The full public MCP tool surface (kept in sync with kintsugi.mcp.tool_specs).


### PR DESCRIPTION
## Summary

Next phase (**P1**) of the MCP server improvement plan, building on the merged P0 hardening (#63). Migrates the MCP server from the low-level `mcp.server.Server` to the bundled **FastMCP**, and delivers **structured tool output**: every tool call now returns machine-readable `structuredContent` alongside the human-readable JSON text block, instead of text only.

## What changed

- **New `src/kintsugi/mcp/tool_specs.py`** — a declarative registry (name → handler module/attr + curated input schema). Plain data with no `mcp` import, so `kintsugi mcp tools` and the tests can read it without the optional `[claude]` extra installed.
- **`server.py` rewritten on FastMCP** — registers all 26 tools with `structured_output=True`. The tool **handler modules are unchanged** (still plain `async` functions returning `dict`s), so the existing unit tests keep calling them directly.
- **Curated input schemas advertised verbatim** — FastMCP's signature-derived input schemas drop the per-parameter descriptions and `enum` constraints the tools rely on, so the server re-asserts the curated schema after registration. Argument *validation* still runs from the handler signatures plus the existing `path_safety` checks; this only changes the contract clients read.
- **Dependency floor** — `mcp>=1.10.0,<2` (structured output requires ≥1.10), in both the `claude` and `dev` extras (the latter so CI can build the FastMCP server in the MCP tests).
- **`kintsugi mcp tools`** now lists the live registry (26 tools; previously a stale hardcoded list of 20).

## Design note (deviation from the approved plan)

The plan proposed per-tool `TypedDict` return types for rich output schemas. Empirical testing against `mcp` 1.27.2 showed that strict `TypedDict`s make FastMCP inject `None` for absent keys and then **fail output validation** (`structuredContent=None`, `isError=True`) on *both* the success and error branches; Optional-field `TypedDict`s validate but pollute every result with null keys. The chosen approach — `dict[str, Any]` returns + `structured_output=True` — emits the faithful dict as `structuredContent` for both the success and the in-band `{"error": ...}` branch, with a generic permissive output schema. Input-schema fidelity (descriptions + enums) is preserved via the registry override instead of rewriting 26 signatures with `Annotated`/`Field`.

## Verification

- `pytest tests/test_mcp_tools.py tests/test_mcp_path_safety.py` → **75 passed, 15 skipped** (skips are optional-dep gated: zarr/dask_image/denoise).
- New in-memory client test asserts every tool has an `outputSchema`, the curated enum/description schema is advertised, and a call returns populated `structuredContent` + a text block.
- `create_server()` `ImportError` contract preserved.
- `ruff` clean; `black` clean on changed files; `mypy` introduces no new errors.
- Smoke: `kintsugi mcp tools` lists 26; `run_server`/`create_server` import path (used by `kintsugi mcp start`) intact.

## Deferred to follow-up PRs

- Read-only MCP **resources** (learning DB, QC summaries, channel listings).
- Tool-surface **consolidation** + wiring the 6 implemented-but-unexposed helper functions.
- **Progress reporting + elicitation** + the analyze→preview→approve→learn **prompt** — now cheap on the FastMCP `Context` this PR establishes.

https://claude.ai/code/session_01LTHtPX7NFSTa8hMjQBRR8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTHtPX7NFSTa8hMjQBRR8o)_